### PR TITLE
fix(directives): change unsubscribe to complete - subject @gigioSouza

### DIFF
--- a/example/app/stock-inventory/components/stock-branch/stock-branch.component.ts
+++ b/example/app/stock-inventory/components/stock-branch/stock-branch.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import {Component, Input} from '@angular/core';
+import {FormGroup} from '@angular/forms';
 
 @Component({
   selector: 'stock-branch',
@@ -7,31 +7,32 @@ import { FormGroup } from '@angular/forms';
   template: `
     <div [formGroup]="parent">
       <div formGroupName="store">
-        
-        <div>
-          <input type="text" placeholder="Branch ID" formControlName="branch">
-        </div>
+        <ng-container *ngIf="!isInput">
+          <div>
+            <input type="text" placeholder="Branch ID" formControlName="branch">
+          </div>
 
-        <div ngxErrors="store.branch">
-          <div class="error" ngxError="required" [when]="['dirty', 'touched']">
-            Branch ID is required
+          <div ngxErrors="store.branch">
+            <div class="error" ngxError="required" [when]="['dirty', 'touched']">
+              Branch ID is required
+            </div>
+            <div class="error" ngxError="invalidBranch" when="dirty">
+              Invalid branch code: 1 letter, 3 numbers
+            </div>
+            <div class="error" ngxError="unknownBranch" when="dirty">
+              Unknown branch, please check the ID
+            </div>
           </div>
-          <div class="error" ngxError="invalidBranch" when="dirty">
-            Invalid branch code: 1 letter, 3 numbers
-          </div>
-          <div class="error" ngxError="unknownBranch" when="dirty">
-            Unknown branch, please check the ID
-          </div>
-        </div>
+        </ng-container>
+        <button  type="button" (click)="toggleInput()">Toggle Branch ID</button>
 
         <div>
           <p>Errors: {{ myError.hasError('*', ['touched']) | json }}</p>
           <p>No Errors: {{ myError.isValid('required', ['dirty']) | json }}</p>
         </div>
-        
-        <input 
-          type="text" 
-          placeholder="Manager Code" 
+        <input
+          type="text"
+          placeholder="Manager Code"
           formControlName="code"
           [class.errors]="myError.hasError('*', ['dirty'])"
           [class.no-errors]="myError.isValid('*', ['dirty'])">
@@ -47,12 +48,15 @@ import { FormGroup } from '@angular/forms';
             Max-length is {{ myError.getError('maxlength')?.requiredLength }}
           </div>
         </div>
-
       </div>
     </div>
   `
 })
 export class StockBranchComponent {
-  @Input()
-  parent: FormGroup;
+  @Input() parent: FormGroup;
+  isInput: boolean;
+
+  toggleInput() {
+    this.isInput = !this.isInput;
+  }
 }

--- a/src/ngxerror.directive.ts
+++ b/src/ngxerror.directive.ts
@@ -1,75 +1,74 @@
-import { Directive, Input, OnInit, OnDestroy, DoCheck, Inject, HostBinding, forwardRef } from '@angular/core';
-
-import { Observable, Subject, Subscription, combineLatest } from 'rxjs';
-
-import { distinctUntilChanged, filter, map } from 'rxjs/operators';
-
-
-
-import { NgxErrorsDirective } from './ngxerrors.directive';
-
-import { ErrorOptions } from './ngxerrors';
-
-import { toArray } from './utils/toArray';
+import {
+  Directive,
+  DoCheck,
+  forwardRef,
+  HostBinding,
+  Inject,
+  Input,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
+import {combineLatest, Observable, Subject, Subscription} from 'rxjs';
+import {distinctUntilChanged, filter, map} from 'rxjs/operators';
+import {ErrorOptions} from './ngxerrors';
+import {NgxErrorsDirective} from './ngxerrors.directive';
+import {toArray} from './utils/toArray';
 
 @Directive({
   selector: '[ngxError]'
 })
 export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
-
-  @Input() set ngxError(value: ErrorOptions) {
+  @Input()
+  set ngxError(value: ErrorOptions) {
     this.errorNames = toArray(value);
   }
 
-  @Input() set when(value: ErrorOptions) {
+  @Input()
+  set when(value: ErrorOptions) {
     this.rules = toArray(value);
   }
 
-  @HostBinding('hidden')
-  hidden: boolean = true;
+  @HostBinding('hidden') private hidden: boolean = true;
 
-  rules: string[] = [];
-
-  errorNames: string[] = [];
-
-  subscription: Subscription;
-
-  _states: Subject<string[]>;
-
-  states: Observable<string[]>;
+  private rules: string[] = [];
+  private errorNames: string[] = [];
+  private subscription: Subscription;
+  private _states$: Subject<string[]>;
+  private states$: Observable<string[]>;
 
   constructor(
-    @Inject(forwardRef(() => NgxErrorsDirective)) private ngxErrors: NgxErrorsDirective
-  ) { }
+    @Inject(forwardRef(() => NgxErrorsDirective))
+    private ngxErrors: NgxErrorsDirective
+  ) {}
 
   ngOnInit() {
+    this._states$ = new Subject<string[]>();
+    this.states$ = this._states$.asObservable().pipe(distinctUntilChanged());
 
-    this._states = new Subject<string[]>();
-    this.states = this._states.asObservable().pipe(distinctUntilChanged());
+    const errors = this.ngxErrors.subject$.pipe(
+      filter(Boolean),
+      filter(obj => !!~this.errorNames.indexOf(obj.errorName))
+    );
 
-    const errors = this.ngxErrors.subject.pipe(
-        filter(Boolean),
-        filter(obj => !!~this.errorNames.indexOf(obj.errorName))
-      );
+    const states = this.states$.pipe(
+      map(states => this.rules.every(rule => !!~states.indexOf(rule)))
+    );
 
-    const states = this.states.pipe(
-        map(states => this.rules.every(rule => !!~states.indexOf(rule)))
-      )
-
-    this.subscription = combineLatest(states, errors).subscribe(([states, errors]) => {
+    this.subscription = combineLatest(states, errors).subscribe(
+      ([states, errors]) => {
         this.hidden = !(states && errors.control.hasError(errors.errorName));
-      });
-
+      }
+    );
   }
 
   ngDoCheck() {
-    this._states.next(
-      this.rules.filter((rule) => (this.ngxErrors.control as any)[rule])
+    this._states$.next(
+      this.rules.filter(rule => (this.ngxErrors.control as any)[rule])
     );
   }
 
   ngOnDestroy() {
+    this._states$.complete();
     this.subscription.unsubscribe();
   }
-
 }


### PR DESCRIPTION
This pull request is related to a bug I found out when testing the ngx-errors to use on my project. I discovered that another user had already opened an issue #22 .
The bug occurs because the BehaviorSubject is closed when ngOnDestroy is called, but don't recieve another instance when a new component is created, making it impossible to use this component with ngIf directive.
Hunting down this bug I found out that the BehaviorSubject references was kind of "dirty" because it was being unsubscribed() when the ngOnDestroy from ngxerrors was being called.
As the ngxerrors wasn't subscribing to it, there was no reason to unsubscribe(), to leave this reference you should complete the subject as the ngxerrors is it's manager.
By completing it, all subscriptions should be already unsubscribed and the components was ready to receive other instance of BehaviorSubject when a new component is created.
And passed the instantiation of the BehaviorSubject to the ngOnInit lifecycle hook.

What are you adding/fixing?
Bug fix #22

Have you added tests for your changes?
I tried to add, but failed. I couldn't test if the fixture.detectChanges() was triggering and error.

Will this need documentation changes?

No

Does this introduce a breaking change?

No

Other information